### PR TITLE
compat: Build with zlib 1.2 to ensure broader compatibility

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/0001-Fix-unsafe-narrowing.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [osx or win]
 
 requirements:
@@ -35,7 +35,8 @@ requirements:
   host:
     - qt
     - openssl
-    - libzlib
+    # 1.2 is ABI compatible with 1.3, so this provides more flexibility
+    - libzlib =1.2
     - zlib
     - freetype
     - libglu                         # [linux]
@@ -69,7 +70,7 @@ outputs:
       host:
         - qt
         - openssl
-        - libzlib
+        - libzlib =1.2
         - zlib
         - freetype
         - libglu                         # [linux]
@@ -105,7 +106,7 @@ outputs:
       host:
         - qt
         - openssl
-        - libzlib
+        - libzlib =1.2
         - zlib
         - freetype
         - libglu                         # [linux]


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

The purpose of this update is to enable connectome-workbench to be installed in environments that require zlib 1.2.x as well as 1.3.x. The latest build of 1.2 declares a compatibility up to `2.0.0.dev`.