### PR TITLE
feat: Add build variants for qt5 and qt6

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,8 +8,8 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_build_variantqt:
-        CONFIG: linux_64_build_variantqt
+      linux_64_build_variantqt5:
+        CONFIG: linux_64_build_variantqt5
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_build_variantqt6:

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,8 +8,12 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_64_build_variantqt:
+        CONFIG: linux_64_build_variantqt
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_build_variantqt6:
+        CONFIG: linux_64_build_variantqt6
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360

--- a/.ci_support/linux_64_build_variantqt.yaml
+++ b/.ci_support/linux_64_build_variantqt.yaml
@@ -20,8 +20,6 @@ freetype:
 - '2'
 openssl:
 - '3'
-qt:
-- '5.15'
 qt6_main:
 - '6.8'
 qt_main:

--- a/.ci_support/linux_64_build_variantqt.yaml
+++ b/.ci_support/linux_64_build_variantqt.yaml
@@ -1,3 +1,5 @@
+build_variant:
+- qt
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -20,6 +22,8 @@ openssl:
 - '3'
 qt:
 - '5.15'
+qt6_main:
+- '6.8'
 qt_main:
 - '5.15'
 target_platform:

--- a/.ci_support/linux_64_build_variantqt5.yaml
+++ b/.ci_support/linux_64_build_variantqt5.yaml
@@ -1,5 +1,5 @@
 build_variant:
-- qt
+- qt5
 c_stdlib:
 - sysroot
 c_stdlib_version:

--- a/.ci_support/linux_64_build_variantqt6.yaml
+++ b/.ci_support/linux_64_build_variantqt6.yaml
@@ -20,8 +20,6 @@ freetype:
 - '2'
 openssl:
 - '3'
-qt:
-- '5.15'
 qt6_main:
 - '6.8'
 qt_main:

--- a/.ci_support/linux_64_build_variantqt6.yaml
+++ b/.ci_support/linux_64_build_variantqt6.yaml
@@ -1,0 +1,32 @@
+build_variant:
+- qt6
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+freetype:
+- '2'
+openssl:
+- '3'
+qt:
+- '5.15'
+qt6_main:
+- '6.8'
+qt_main:
+- '5.15'
+target_platform:
+- linux-64
+zlib:
+- '1'

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output
+# Pixi's configuration
+.pixi

--- a/README.md
+++ b/README.md
@@ -36,10 +36,17 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
+              <td>linux_64_build_variantqt</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24103&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/connectome-workbench-split-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/connectome-workbench-split-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_variantqt" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_build_variantqt6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24103&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/connectome-workbench-split-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_variantqt6" alt="variant">
                 </a>
               </td>
             </tr>
@@ -173,5 +180,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@coalsont](https://github.com/coalsont/)
 * [@effigies](https://github.com/effigies/)
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_build_variantqt</td>
+              <td>linux_64_build_variantqt5</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24103&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/connectome-workbench-split-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_variantqt" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/connectome-workbench-split-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_variantqt5" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,6 +7,11 @@ if [[ "$target_platform" == linux-* ]]; then
     export CXX_FLAGS="$CXX_FLAGS -lGL -lGLU"
 fi
 
+if [[ "$build_variant" == "qt6" ]]; then
+    export WORKBENCH_USE_QT5=FALSE
+    export WORKBENCH_USE_QT6=TRUE
+fi
+
 cmake $CMAKE_ARGS -GNinja \
     -DCMAKE_BUILD_TYPE:STRING=Release \
     -DCMAKE_INSTALL_PREFIX:STRING=$PREFIX \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,9 +10,17 @@ fi
 if [[ "$build_variant" == "qt6" ]]; then
     export WORKBENCH_USE_QT5=FALSE
     export WORKBENCH_USE_QT6=TRUE
+elif [[ "$build_variant" == "qt5" ]]; then
+    export WORKBENCH_USE_QT5=TRUE
+    export WORKBENCH_USE_QT6=FALSE
+else
+    echo "Unknown build variant: $build_variant"
+    exit 1
 fi
 
 cmake $CMAKE_ARGS -GNinja \
+    -DWORKBENCH_USE_QT5:BOOL=$WORKBENCH_USE_QT5 \
+    -DWORKBENCH_USE_QT6:BOOL=$WORKBENCH_USE_QT6 \
     -DCMAKE_BUILD_TYPE:STRING=Release \
     -DCMAKE_INSTALL_PREFIX:STRING=$PREFIX \
     -DCMAKE_CXX_FLAGS="$CXX_FLAGS" \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+build_variant:
+  - "qt"
+  - "qt6"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,3 @@
 build_variant:
-  - "qt"
+  - "qt5"
   - "qt6"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,13 +37,13 @@ requirements:
     - {{ cdt('libxxf86vm') }}        # [linux]
     - {{ cdt('libxext') }}           # [linux]
   host:
-    - noqt6                          # [build_variant == "qt"]
+    - noqt6                          # [build_variant == "qt5"]
     - noqt5                          # [build_variant == "qt6"]
-    - qt-main                        # [build_variant == "qt"]
+    - qt-main                        # [build_variant == "qt5"]
     - qt6-main                       # [build_variant == "qt6"]
     - openssl
     # 1.2 is ABI compatible with 1.3, so this provides more flexibility
-    - libzlib =1.2                   # [build_variant == "qt"]
+    - libzlib =1.2                   # [build_variant == "qt5"]
     # qt6 is build with 1.3
     - libzlib =1.3                   # [build_variant == "qt6"]
     - zlib
@@ -77,12 +77,12 @@ outputs:
         - {{ cdt('libxxf86vm') }}        # [linux]
         - {{ cdt('libxext') }}           # [linux]
       host:
-        - noqt6                          # [build_variant == "qt"]
+        - noqt6                          # [build_variant == "qt5"]
         - noqt5                          # [build_variant == "qt6"]
-        - qt-main                        # [build_variant == "qt"]
+        - qt-main                        # [build_variant == "qt5"]
         - qt6-main                       # [build_variant == "qt6"]
         - openssl
-        - libzlib =1.2                   # [build_variant == "qt"]
+        - libzlib =1.2                   # [build_variant == "qt5"]
         - libzlib =1.3                   # [build_variant == "qt6"]
         - zlib
         - freetype
@@ -116,12 +116,12 @@ outputs:
         - {{ cdt('libxxf86vm') }}        # [linux]
         - {{ cdt('libxext') }}           # [linux]
       host:
-        - noqt6                          # [build_variant == "qt"]
+        - noqt6                          # [build_variant == "qt5"]
         - noqt5                          # [build_variant == "qt6"]
-        - qt-main                        # [build_variant == "qt"]
+        - qt-main                        # [build_variant == "qt5"]
         - qt6-main                       # [build_variant == "qt6"]
         - openssl
-        - libzlib =1.2                   # [build_variant == "qt"]
+        - libzlib =1.2                   # [build_variant == "qt5"]
         - libzlib =1.3                   # [build_variant == "qt6"]
         - zlib
         - freetype

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,8 @@ requirements:
     - {{ cdt('libxxf86vm') }}        # [linux]
     - {{ cdt('libxext') }}           # [linux]
   host:
+    - noqt6                          # [build_variant == "qt"]
+    - noqt5                          # [build_variant == "qt6"]
     - qt-main                        # [build_variant == "qt"]
     - qt6-main                       # [build_variant == "qt6"]
     - openssl
@@ -75,6 +77,8 @@ outputs:
         - {{ cdt('libxxf86vm') }}        # [linux]
         - {{ cdt('libxext') }}           # [linux]
       host:
+        - noqt6                          # [build_variant == "qt"]
+        - noqt5                          # [build_variant == "qt6"]
         - qt-main                        # [build_variant == "qt"]
         - qt6-main                       # [build_variant == "qt6"]
         - openssl
@@ -112,6 +116,8 @@ outputs:
         - {{ cdt('libxxf86vm') }}        # [linux]
         - {{ cdt('libxext') }}           # [linux]
       host:
+        - noqt6                          # [build_variant == "qt"]
+        - noqt5                          # [build_variant == "qt6"]
         - qt-main                        # [build_variant == "qt"]
         - qt6-main                       # [build_variant == "qt6"]
         - openssl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,8 @@
 {% set name = "connectome-workbench" %}
 {% set version = "2.0.1" %}
+{% set build = 2 %}
+
+{% set build = build + 100 %}  # [build_variant == "qt6"]
 
 package:
   name: {{ name }}-split
@@ -13,7 +16,8 @@ source:
     - patches/0001-Fix-unsafe-narrowing.patch
 
 build:
-  number: 1
+  number: {{ build }}
+  string: "{{ build_variant }}_h{{ PKG_HASH }}_{{ build }}"
   skip: true  # [osx or win]
 
 requirements:
@@ -33,7 +37,8 @@ requirements:
     - {{ cdt('libxxf86vm') }}        # [linux]
     - {{ cdt('libxext') }}           # [linux]
   host:
-    - qt
+    - qt                             # [build_variant == "qt"]
+    - qt6                            # [build_variant == "qt6"]
     - openssl
     # 1.2 is ABI compatible with 1.3, so this provides more flexibility
     - libzlib =1.2
@@ -68,7 +73,8 @@ outputs:
         - {{ cdt('libxxf86vm') }}        # [linux]
         - {{ cdt('libxext') }}           # [linux]
       host:
-        - qt
+        - qt                             # [build_variant == "qt"]
+        - qt6                            # [build_variant == "qt6"]
         - openssl
         - libzlib =1.2
         - zlib
@@ -76,9 +82,10 @@ outputs:
         - libglu                         # [linux]
         - glew                           # [windows]
       run:
-        - qt-main
-        - libgl                             # [linux]
-        - libglu                            # [linux]
+        - qt-main                        # [build_variant == "qt"]
+        - qt6-main                       # [build_variant == "qt6"]
+        - libgl                          # [linux]
+        - libglu                         # [linux]
     files:
       include:
         - bin/wb_view
@@ -104,7 +111,8 @@ outputs:
         - {{ cdt('libxxf86vm') }}        # [linux]
         - {{ cdt('libxext') }}           # [linux]
       host:
-        - qt
+        - qt                             # [build_variant == "qt"]
+        - qt6                            # [build_variant == "qt6"]
         - openssl
         - libzlib =1.2
         - zlib
@@ -112,9 +120,10 @@ outputs:
         - libglu                         # [linux]
         - glew                           # [windows]
       run:
-        - qt-main
-        - libgl                             # [linux]
-        - libglu                            # [linux]
+        - qt-main                        # [build_variant == "qt"]
+        - qt6-main                       # [build_variant == "qt6"]
+        - libgl                          # [linux]
+        - libglu                         # [linux]
     files:
       include:
         - bin/wb_command

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,8 +37,8 @@ requirements:
     - {{ cdt('libxxf86vm') }}        # [linux]
     - {{ cdt('libxext') }}           # [linux]
   host:
-    - qt                             # [build_variant == "qt"]
-    - qt6                            # [build_variant == "qt6"]
+    - qt-main                        # [build_variant == "qt"]
+    - qt6-main                       # [build_variant == "qt6"]
     - openssl
     # 1.2 is ABI compatible with 1.3, so this provides more flexibility
     - libzlib =1.2
@@ -73,8 +73,8 @@ outputs:
         - {{ cdt('libxxf86vm') }}        # [linux]
         - {{ cdt('libxext') }}           # [linux]
       host:
-        - qt                             # [build_variant == "qt"]
-        - qt6                            # [build_variant == "qt6"]
+        - qt-main                        # [build_variant == "qt"]
+        - qt6-main                       # [build_variant == "qt6"]
         - openssl
         - libzlib =1.2
         - zlib
@@ -82,8 +82,6 @@ outputs:
         - libglu                         # [linux]
         - glew                           # [windows]
       run:
-        - qt-main                        # [build_variant == "qt"]
-        - qt6-main                       # [build_variant == "qt6"]
         - libgl                          # [linux]
         - libglu                         # [linux]
     files:
@@ -111,8 +109,8 @@ outputs:
         - {{ cdt('libxxf86vm') }}        # [linux]
         - {{ cdt('libxext') }}           # [linux]
       host:
-        - qt                             # [build_variant == "qt"]
-        - qt6                            # [build_variant == "qt6"]
+        - qt-main                        # [build_variant == "qt"]
+        - qt6-main                       # [build_variant == "qt6"]
         - openssl
         - libzlib =1.2
         - zlib
@@ -120,8 +118,6 @@ outputs:
         - libglu                         # [linux]
         - glew                           # [windows]
       run:
-        - qt-main                        # [build_variant == "qt"]
-        - qt6-main                       # [build_variant == "qt6"]
         - libgl                          # [linux]
         - libglu                         # [linux]
     files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,9 @@ requirements:
     - qt6-main                       # [build_variant == "qt6"]
     - openssl
     # 1.2 is ABI compatible with 1.3, so this provides more flexibility
-    - libzlib =1.2
+    - libzlib =1.2                   # [build_variant == "qt"]
+    # qt6 is build with 1.3
+    - libzlib =1.3                   # [build_variant == "qt6"]
     - zlib
     - freetype
     - libglu                         # [linux]
@@ -76,7 +78,8 @@ outputs:
         - qt-main                        # [build_variant == "qt"]
         - qt6-main                       # [build_variant == "qt6"]
         - openssl
-        - libzlib =1.2
+        - libzlib =1.2                   # [build_variant == "qt"]
+        - libzlib =1.3                   # [build_variant == "qt6"]
         - zlib
         - freetype
         - libglu                         # [linux]
@@ -112,7 +115,8 @@ outputs:
         - qt-main                        # [build_variant == "qt"]
         - qt6-main                       # [build_variant == "qt6"]
         - openssl
-        - libzlib =1.2
+        - libzlib =1.2                   # [build_variant == "qt"]
+        - libzlib =1.3                   # [build_variant == "qt6"]
         - zlib
         - freetype
         - libglu                         # [linux]


### PR DESCRIPTION
This PR aims to build variants for qt5 and qt6, so connectome-workbench does not over-constrain an environment where some packages may only be available for one or the other.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

I'm basing this off of looking at what was undone in https://github.com/conda-forge/vtk-feedstock/pull/368. @larsoner I would appreciate any advice you could give on managing build variants.