### PR TITLE
Patch freetype

### DIFF
--- a/.ci_support/linux_64_build_variantqt5.yaml
+++ b/.ci_support/linux_64_build_variantqt5.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+freetype:
+- '2'
 glib:
 - '2'
 openssl:

--- a/.ci_support/linux_64_build_variantqt6.yaml
+++ b/.ci_support/linux_64_build_variantqt6.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+freetype:
+- '2'
 glib:
 - '2'
 openssl:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,15 +23,23 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_build_variantqt5
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
           - CONFIG: linux_64_build_variantqt6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
     steps:
 
     - name: Checkout code
@@ -41,11 +49,13 @@ jobs:
       id: build-linux
       if: matrix.os == 'ubuntu'
       env:
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CONFIG: ${{ matrix.CONFIG }}
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
         DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
         CI: github_actions
-        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.CONDA_FORGE_DOCKER_RUN_ARGS }}"
+        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.docker_run_args }}"
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
@@ -65,6 +75,8 @@ jobs:
         else
           export IS_PR_BUILD="False"
         fi
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         echo "::endgroup::"
         ./.scripts/run_docker_build.sh
 
@@ -72,6 +84,8 @@ jobs:
       id: build-macos
       if: matrix.os == 'macos'
       env:
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CONFIG: ${{ matrix.CONFIG }}
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
         CI: github_actions
@@ -90,6 +104,8 @@ jobs:
         else
           export IS_PR_BUILD="False"
         fi
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         ./.scripts/run_osx_build.sh
 
     - name: Build on windows
@@ -102,10 +118,8 @@ jobs:
         set "sha=%GITHUB_SHA%"
         call ".scripts\run_win_build.bat"
       env:
-        # default value; make it explicit, as it needs to match with artefact
-        # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
-        MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}
         CI: github_actions

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!.recipe_maintainers.json
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -36,7 +36,7 @@ mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-
 echo > /opt/conda/conda-meta/history
 micromamba install --root-prefix ~/.conda --prefix /opt/conda \
     --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=26.3"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc

--- a/README.md
+++ b/README.md
@@ -22,7 +22,14 @@ Current build status
 ====================
 
 
-<table>
+<table><tr>
+    <td>GitHub Actions</td>
+    <td>
+      <a href="https://github.com/conda-forge/connectome-workbench-split-feedstock/actions/workflows/conda-build.yml">
+        <img src="https://github.com/conda-forge/connectome-workbench-split-feedstock/actions/workflows/conda-build.yml/badge.svg?event=push&branch=main">
+      </a>
+    </td>
+  </tr>
 </table>
 
 Current release info

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,9 @@ source:
     - patches/0001-Import-cstdint-into-libCZI.h.patch
     - patches/0001-Fix-unsafe-narrowing.patch
     - patches/0001-chore-build-Find-QuaZip-library.patch
+    # Included in v2.1.0-222-gb08bb2854, remove after next release
+    - 0001-FreeType-2.13-changed-a-type-from-char-to-unsigned-c.patch
+    - 0002-Another-fix-for-FreeType-2.13-by-adding-a-char-cast-.patch
 
 build:
   number: {{ build }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "connectome-workbench" %}
 {% set version = "2.0.1" %}
-{% set build = 5 %}
+{% set build = 6 %}
 
 {% set build = build + 100 %}  # [build_variant == "qt6"]
 
@@ -16,8 +16,8 @@ source:
     - patches/0001-Fix-unsafe-narrowing.patch
     - patches/0001-chore-build-Find-QuaZip-library.patch
     # Included in v2.1.0-222-gb08bb2854, remove after next release
-    - 0001-FreeType-2.13-changed-a-type-from-char-to-unsigned-c.patch
-    - 0002-Another-fix-for-FreeType-2.13-by-adding-a-char-cast-.patch
+    - patches/0001-FreeType-2.13-changed-a-type-from-char-to-unsigned-c.patch
+    - patches/0002-Another-fix-for-FreeType-2.13-by-adding-a-char-cast-.patch
 
 build:
   number: {{ build }}
@@ -46,8 +46,7 @@ requirements:
     - noqt6                          # [build_variant == "qt5"]
     - noqt5                          # [build_variant == "qt6"]
     - qt-main                        # [build_variant == "qt5"]
-    # upper bound for freetype constraint
-    - qt6-main >6,<6.10              # [build_variant == "qt6"]
+    - qt6-main >6                    # [build_variant == "qt6"]
     - glib                           # [linux]
     - openssl
     # 1.2 is ABI compatible with 1.3, so this provides more flexibility
@@ -55,10 +54,9 @@ requirements:
     # qt6 is build with 1.3
     - libzlib =1.3                   # [build_variant == "qt6"]
     - zlib
-    # No qt6 build yet with old enough freetype support, use vendored
     - quazip <1.4                    # [build_variant == "qt5"]
-    # https://github.com/Washington-University/workbench/issues/97
-    - freetype <2.13.3
+    - quazip                         # [build_variant == "qt6"]
+    - freetype
     - libglu                         # [linux]
     - glew                           # [windows]
     - mesalib <25.1                  # [linux]
@@ -94,16 +92,15 @@ outputs:
         - noqt6                          # [build_variant == "qt5"]
         - noqt5                          # [build_variant == "qt6"]
         - qt-main                        # [build_variant == "qt5"]
-        # upper bound for freetype constraint
-        - qt6-main >6,<6.10              # [build_variant == "qt6"]
+        - qt6-main >6                    # [build_variant == "qt6"]
         - openssl
         - glib                           # [linux]
         - libzlib =1.2                   # [build_variant == "qt5"]
         - libzlib =1.3                   # [build_variant == "qt6"]
         - zlib
         - quazip <1.4                    # [build_variant == "qt5"]
-        # https://github.com/Washington-University/workbench/issues/97
-        - freetype <2.13.3
+        - quazip                         # [build_variant == "qt6"]
+        - freetype
         - libglu                         # [linux]
         - glew                           # [windows]
         - mesalib <25.1                  # [linux]
@@ -112,6 +109,7 @@ outputs:
         - libglu                         # [linux]
         - mesalib <25.1                  # [linux]
         - quazip <1.4                    # [build_variant == "qt5"]
+        - quazip                         # [build_variant == "qt6"]
     files:
       include:
         - bin/wb_view
@@ -142,16 +140,15 @@ outputs:
         - noqt6                          # [build_variant == "qt5"]
         - noqt5                          # [build_variant == "qt6"]
         - qt-main                        # [build_variant == "qt5"]
-        # upper bound for freetype constraint
-        - qt6-main >6,<6.10              # [build_variant == "qt6"]
+        - qt6-main >6                    # [build_variant == "qt6"]
         - openssl
         - glib                           # [linux]
         - libzlib =1.2                   # [build_variant == "qt5"]
         - libzlib =1.3                   # [build_variant == "qt6"]
         - zlib
         - quazip <1.4                    # [build_variant == "qt5"]
-        # https://github.com/Washington-University/workbench/issues/97
-        - freetype <2.13.3
+        - quazip                         # [build_variant == "qt6"]
+        - freetype
         - libglu                         # [linux]
         - glew                           # [windows]
         - mesalib <25.1                  # [linux]
@@ -160,6 +157,7 @@ outputs:
         - libglu                         # [linux]
         - mesalib <25.1                  # [linux]
         - quazip <1.4                    # [build_variant == "qt5"]
+        - quazip                         # [build_variant == "qt6"]
     files:
       include:
         - bin/wb_command

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,11 +37,9 @@ requirements:
     - llvm-openmp  # [osx]
     - libgomp      # [linux]
     # libGL
-    - {{ cdt('mesa-libgl-devel') }}  # [linux]
-    - {{ cdt('mesa-dri-drivers') }}  # [linux]
-    - {{ cdt('libxdamage') }}        # [linux]
-    - {{ cdt('libxxf86vm') }}        # [linux]
-    - {{ cdt('libxext') }}           # [linux]
+    - {{ cdt('mesa-libgl-devel') }}  # [linux and build_variant == "qt5"]
+    - libgl-devel                    # [linux]
+    - libglx-devel                   # [linux]
   host:
     - noqt6                          # [build_variant == "qt5"]
     - noqt5                          # [build_variant == "qt6"]
@@ -83,11 +81,9 @@ outputs:
         - llvm-openmp  # [osx]
         - libgomp      # [linux]
         # libGL
-        - {{ cdt('mesa-libgl-devel') }}  # [linux]
-        - {{ cdt('mesa-dri-drivers') }}  # [linux]
-        - {{ cdt('libxdamage') }}        # [linux]
-        - {{ cdt('libxxf86vm') }}        # [linux]
-        - {{ cdt('libxext') }}           # [linux]
+        - {{ cdt('mesa-libgl-devel') }}  # [linux and build_variant == "qt5"]
+        - libgl-devel                    # [linux]
+        - libglx-devel                   # [linux]
       host:
         - noqt6                          # [build_variant == "qt5"]
         - noqt5                          # [build_variant == "qt6"]
@@ -131,11 +127,9 @@ outputs:
         - llvm-openmp  # [osx]
         - libgomp      # [linux]
         # libGL
-        - {{ cdt('mesa-libgl-devel') }}  # [linux]
-        - {{ cdt('mesa-dri-drivers') }}  # [linux]
-        - {{ cdt('libxdamage') }}        # [linux]
-        - {{ cdt('libxxf86vm') }}        # [linux]
-        - {{ cdt('libxext') }}           # [linux]
+        - {{ cdt('mesa-libgl-devel') }}  # [linux and build_variant == "qt5"]
+        - libgl-devel                    # [linux]
+        - libglx-devel                   # [linux]
       host:
         - noqt6                          # [build_variant == "qt5"]
         - noqt5                          # [build_variant == "qt6"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,12 +52,13 @@ requirements:
     # qt6 is build with 1.3
     - libzlib =1.3                   # [build_variant == "qt6"]
     - zlib
-    - quazip <1.4                    # [build_variant == "qt5"]
-    - quazip                         # [build_variant == "qt6"]
+    - quazip <1.4                    # [linux and build_variant == "qt5"]
+    - quazip                         # [linux and build_variant == "qt6"]
     - freetype
     - libglu                         # [linux]
     - glew                           # [windows]
-    - mesalib <25.1                  # [linux]
+    - mesalib <25.1                  # [linux and build_variant == "qt5"]
+    - mesalib                        # [linux and build_variant == "qt6"]
 
 test:
   commands:
@@ -94,18 +95,20 @@ outputs:
         - libzlib =1.2                   # [build_variant == "qt5"]
         - libzlib =1.3                   # [build_variant == "qt6"]
         - zlib
-        - quazip <1.4                    # [build_variant == "qt5"]
-        - quazip                         # [build_variant == "qt6"]
+        - quazip <1.4                    # [linux and build_variant == "qt5"]
+        - quazip                         # [linux and build_variant == "qt6"]
         - freetype
         - libglu                         # [linux]
         - glew                           # [windows]
-        - mesalib <25.1                  # [linux]
+        - mesalib <25.1                  # [linux and build_variant == "qt5"]
+        - mesalib                        # [linux and build_variant == "qt6"]
       run:
         - libgl                          # [linux]
         - libglu                         # [linux]
-        - mesalib <25.1                  # [linux]
-        - quazip <1.4                    # [build_variant == "qt5"]
-        - quazip                         # [build_variant == "qt6"]
+        - mesalib <25.1                  # [linux and build_variant == "qt5"]
+        - mesalib                        # [linux and build_variant == "qt6"]
+        - quazip <1.4                    # [linux and build_variant == "qt5"]
+        - quazip                         # [linux and build_variant == "qt6"]
     files:
       include:
         - bin/wb_view
@@ -140,18 +143,20 @@ outputs:
         - libzlib =1.2                   # [build_variant == "qt5"]
         - libzlib =1.3                   # [build_variant == "qt6"]
         - zlib
-        - quazip <1.4                    # [build_variant == "qt5"]
-        - quazip                         # [build_variant == "qt6"]
+        - quazip <1.4                    # [linux and build_variant == "qt5"]
+        - quazip                         # [linux and build_variant == "qt6"]
         - freetype
         - libglu                         # [linux]
         - glew                           # [windows]
-        - mesalib <25.1                  # [linux]
+        - mesalib <25.1                  # [linux and build_variant == "qt5"]
+        - mesalib                        # [linux and build_variant == "qt6"]
       run:
         - libgl                          # [linux]
         - libglu                         # [linux]
-        - mesalib <25.1                  # [linux]
-        - quazip <1.4                    # [build_variant == "qt5"]
-        - quazip                         # [build_variant == "qt6"]
+        - mesalib <25.1                  # [linux and build_variant == "qt5"]
+        - mesalib                        # [linux and build_variant == "qt6"]
+        - quazip <1.4                    # [linux and build_variant == "qt5"]
+        - quazip                         # [linux and build_variant == "qt6"]
     files:
       include:
         - bin/wb_command

--- a/recipe/patches/0001-FreeType-2.13-changed-a-type-from-char-to-unsigned-c.patch
+++ b/recipe/patches/0001-FreeType-2.13-changed-a-type-from-char-to-unsigned-c.patch
@@ -1,0 +1,33 @@
+From 72c644e3d5db3aa254805cace0f24929c52fe61d Mon Sep 17 00:00:00 2001
+From: John Harwell <jharwell@wustl.edu>
+Date: Tue, 24 Mar 2026 16:38:41 -0500
+Subject: [PATCH 1/2] FreeType 2.13 changed a type from 'char*' to 'unsigned
+ char*' causing a compilation error on a variable declaration in
+ FTVectoriser.cpp.  To fix it, I replaced 'char*' with 'auto' in the variable
+ declaration in FTVectoriser.cpp.
+
+---
+ src/FtglFont/FTVectoriser.cpp | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/FtglFont/FTVectoriser.cpp b/src/FtglFont/FTVectoriser.cpp
+index 4ab3adffd..0c361f74d 100644
+--- a/src/FtglFont/FTVectoriser.cpp
++++ b/src/FtglFont/FTVectoriser.cpp
+@@ -174,7 +174,12 @@ void FTVectoriser::ProcessContours()
+     for(int i = 0; i < ftContourCount; ++i)
+     {
+         FT_Vector* pointList = &outline.points[startIndex];
+-        char* tagList = &outline.tags[startIndex];
++        /* 
++         * JWH 24mar2026
++         * Freetype 2.13 changed 'char*' to 'unsigned char*' 
++         * Replaced 'char*' with auto; 
++         */
++        auto tagList = &outline.tags[startIndex];
+ 
+         endIndex = outline.contours[i];
+         contourLength =  (endIndex - startIndex) + 1;
+-- 
+2.54.0
+

--- a/recipe/patches/0002-Another-fix-for-FreeType-2.13-by-adding-a-char-cast-.patch
+++ b/recipe/patches/0002-Another-fix-for-FreeType-2.13-by-adding-a-char-cast-.patch
@@ -1,0 +1,30 @@
+From 4207ebc77441155efb778c27901fb95f497aedc9 Mon Sep 17 00:00:00 2001
+From: John Harwell <jharwell@wustl.edu>
+Date: Wed, 25 Mar 2026 11:34:37 -0500
+Subject: [PATCH 2/2] Another fix for FreeType 2.13 by adding a 'char*' cast to
+ the second argument to the FTContour constructor call.
+
+---
+ src/FtglFont/FTVectoriser.cpp | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/FtglFont/FTVectoriser.cpp b/src/FtglFont/FTVectoriser.cpp
+index 0c361f74d..0fecd5462 100644
+--- a/src/FtglFont/FTVectoriser.cpp
++++ b/src/FtglFont/FTVectoriser.cpp
+@@ -184,7 +184,11 @@ void FTVectoriser::ProcessContours()
+         endIndex = outline.contours[i];
+         contourLength =  (endIndex - startIndex) + 1;
+ 
+-        FTContour* contour = new FTContour(pointList, tagList, contourLength);
++        /*
++         * Another fix forf 2.13.  Cast tagList to 'char*'.
++         * In 2.13 'tagList' is 'unsigned char*'
++         */
++        FTContour* contour = new FTContour(pointList, (char*)tagList, contourLength);
+ 
+         contourList[i] = contour;
+ 
+-- 
+2.54.0
+


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This PR applies patches https://github.com/Washington-University/workbench/commit/2fda696cc2f555ee36a4fdf27f1f0b79e9362083 and https://github.com/Washington-University/workbench/commit/3c3bf09e0b10db1d9fb61dc7ababb9bc94c66a37 (addressing https://github.com/Washington-University/workbench/issues/97).

This PR also addresses https://github.com/conda-forge/connectome-workbench-split-feedstock/pull/20#issuecomment-4592461830 and relaxes the quazip and mesalib constraints for the qt6 build (cannot do these things for qt5).

This will hopefully address issues preventing updating to 2.1.0.